### PR TITLE
Fix certificate configuration crash

### DIFF
--- a/app/src/main/java/online/taxcore/pos/data/services/DownloadService.kt
+++ b/app/src/main/java/online/taxcore/pos/data/services/DownloadService.kt
@@ -64,6 +64,9 @@ object DownloadService {
 
                 val documentsFolder =
                     Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
+                if(!documentsFolder.exists()) {
+                    documentsFolder.mkdir()
+                }
 
                 val fileNameBase = downloadUrl.substring(downloadUrl.lastIndexOf("/") + 1).ifBlank {
                     UUID.randomUUID().toString()


### PR DESCRIPTION
This update checks if the documents folder exists and creates the folder if it doesn't exist before accessing the folder or files in that folder.